### PR TITLE
Discord embed - Beautify & Add version info

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -6,11 +6,12 @@ import {
 } from "../lib/parser";
 import { remap } from "./remap";
 import { join } from "node:path";
-import { addrsToPlainText, formatMarkdown } from "../lib/format";
+import { addrsToPlainText, formatMarkdown, os_names } from "../lib/format";
 import { garbageCollect, tagIssue } from "./db";
 import { verify } from "@octokit/webhooks-methods";
 import { escapeHTML, remapCacheKey } from "../lib/util";
 import { sendToSentry } from "./sentry";
+import { getCommit } from "./git";
 
 process.env.NODE_ENV ||= "development";
 
@@ -19,8 +20,8 @@ const html =
     ? await Bun.file(join(import.meta.dir, "index.html")).arrayBuffer()
     : null;
 
-function getPathname(url: string) {
-  let pathname = new URL(url).pathname;
+function getPathname(url: URL) {
+  let pathname = url.pathname;
 
   while (pathname.startsWith("//")) {
     pathname = pathname.slice(1);
@@ -46,7 +47,8 @@ export default {
       return postRequest(request, server);
     }
 
-    const pathname = getPathname(request.url);
+    const request_url = new URL(request.url);
+    const pathname = getPathname(request_url);
 
     // Development
     if (process.env.NODE_ENV === "development") {
@@ -108,6 +110,70 @@ export default {
       );
     }
 
+    // Discord bot crawling
+    if (request.headers.get("user-agent")?.includes("discord")) {
+      
+      if (pathname.endsWith("/oembed.json")) {
+        const str = pathname.slice(1, -12);
+
+        return parse(str).then(async (parsed) => {
+          if (!parsed) {
+            return new Response("Not found", { status: 404 });
+          }
+
+          const arch = parsed.arch.split("_baseline");
+          let { oid } = await getCommit(parsed.commitish).catch(_ => null) ?? {};
+
+          const oembed: { [key: string]: string } = {
+            author_name: parsed.message,
+            author_url: `${request_url.origin}/${encodeURI(str)}/view`,
+            provider_name: `Bun v${parsed.version} (${parsed.commitish}) on ${os_names[parsed.os[0]]} ${arch[0]}${arch.length > 1 ? " (baseline)" : ""}`,
+            type: "link",
+            version: "1.0"
+          };
+
+          if (oid !== undefined) {
+            oembed.provider_url = `https://github.com/oven-sh/bun/tree/${oid}`;
+          }
+
+          return Response.json(oembed);
+        });
+      }
+
+      // Respond with the same metadata if user tries to be helpful by adding "/view"
+      const str = pathname.endsWith("/view") ? pathname.slice(1, -5) : pathname.slice(1);
+
+      return parse(str).then(async (parsed) => {
+        if (!parsed) {
+          return new Response("Not found", { status: 404 });
+        }
+
+        let metadata_tags = `<meta name="theme-color" content="#f472b6">
+        <meta content="https://bun.sh/logo-square@16px.png" property="og:image">
+        <link type="application/json+oembed" href="${request_url.origin}/${encodeURI(str)}/oembed.json" />`;
+
+        try {
+          const remapped = await remap(str, parsed);
+
+          const embed_description = addrsToPlainText(
+            remapped.commit.oid,
+            remapped.addresses
+          ).join("\n");
+
+          metadata_tags += `<meta property=og:description content="${escapeHTML(embed_description)}">`;
+        } catch (e) {}
+
+        return new Response(
+          metadata_tags,
+          {
+            headers: {
+              "Content-Type": "text/html; charset=utf-8"
+            },
+          }
+        );
+      });
+    }
+
     if (pathname.endsWith("/view")) {
       return new Response("Not found", {
         status: 307,
@@ -152,10 +218,7 @@ export default {
         return new Response("Not found", { status: 404 });
       }
 
-      const is_discord_bot =
-        request.headers.get("user-agent")?.includes("discord") ?? false;
-
-      return remapAndRedirect(str, parsed, is_discord_bot, request.headers);
+      return remapAndRedirect(str, parsed, request.headers);
     });
   },
   error(err) {
@@ -166,7 +229,7 @@ export default {
 
 // Post requests
 function postRequest(request: Request, server: Server) {
-  const pathname = getPathname(request.url);
+  const pathname = getPathname(new URL(request.url));
 
   switch (pathname) {
     case "/remap":
@@ -248,7 +311,6 @@ const install_template = "7-install-crash-report.yml";
 async function remapAndRedirect(
   parsed_str: string,
   parsed: Parse,
-  is_discord_bot: boolean,
   headers: Headers,
 ) {
   try {
@@ -258,11 +320,9 @@ async function remapAndRedirect(
       return new Response("Failed to remap", { status: 500 });
     }
 
-    if (!is_discord_bot) {
-      sendToSentry(parsed, remapped).catch((e) => {
-        console.error("Failed to send to sentry", e);
-      });
-    }
+    sendToSentry(parsed, remapped).catch((e) => {
+      console.error("Failed to send to sentry", e);
+    });
 
     if (remapped.issue) {
       return Response.redirect(
@@ -271,24 +331,6 @@ async function remapAndRedirect(
       );
     }
 
-    if (is_discord_bot) {
-      const embed_title = remapped.message;
-      const embed_description = addrsToPlainText(
-        remapped.commit.oid,
-        remapped.addresses,
-      ).join("\n");
-
-      return new Response(
-        `<meta property=og:title content="${escapeHTML(embed_title)}">
-<meta property=og:description content="${escapeHTML(embed_description)}">
-`,
-        {
-          headers: {
-            "Content-Type": "text/html; charset=utf-8",
-          },
-        },
-      );
-    }
 
     const markdown = formatMarkdown(remapped);
     const template = remapped.command === "InstallCommand" ? install_template : default_template;

--- a/frontend/frontend.ts
+++ b/frontend/frontend.ts
@@ -1,4 +1,5 @@
 import type { Parse, RemapAPIResponse } from "../lib/parser";
+import { os_names } from "../lib/format";
 
 import { parse } from "../lib/parser";
 import { parseCacheKey, debounce, escapeHTML as eschtml } from "../lib/util";
@@ -227,12 +228,6 @@ function cardHead() {
   )}</code></p>
   `;
 }
-
-const os_names: { [key: string]: string } = {
-  w: "Windows",
-  m: "macOS",
-  l: "Linux",
-};
 
 function cardFooter() {
   parsed = parsed!;

--- a/lib/format.ts
+++ b/lib/format.ts
@@ -3,6 +3,12 @@ import { basename, escmd, escmdcode } from "./util";
 
 import type { Remap } from "./parser";
 
+export const os_names: { [key: string]: string } = {
+  w: "Windows",
+  m: "macOS",
+  l: "Linux",
+};
+
 export function formatMarkdown(
   remap: Remap,
   internal?: { source: string },


### PR DESCRIPTION
This PR beautifies and adds the bun version info to embeds when https://bun.report/.../ is shared on Discord.

oEmbed metadata will be sent in response to requests from Discord. Discord will send an additional request to https://bun.report/.../oembed.json for each shared link.

### Before:
![image](https://github.com/user-attachments/assets/da53b9e0-405f-4015-ab82-5c609ce32712)

### After:
The provider URL (small link at the top of embed) is set to the git revision and the author URL to https://bun.report/.../view.
![image](https://github.com/user-attachments/assets/4f9b3c9e-79b9-40ea-9b0a-358d1f44b1bf)


Tested locally using `lib.ts`'s `remap()`.