### PR TITLE
fix: Avoid bundling of zlib on frontend

### DIFF
--- a/lib/parser.ts
+++ b/lib/parser.ts
@@ -1,6 +1,5 @@
 import { type Platform, type Arch } from "./util";
 import { decodePart } from "./vlq";
-import zlib from 'zlib';
 
 declare const DEBUG: boolean;
 if (typeof DEBUG === "undefined") {
@@ -252,7 +251,7 @@ function parsePanicMessage(
       return (
         "panic: " +
         new TextDecoder().decode(
-          zlib.inflateSync(Buffer.from(message_compressed, "base64url")),
+          Bun.inflateSync(Buffer.from(message_compressed, "base64url"), { windowBits: 0 }),
         )
       );
     } catch (e) {


### PR DESCRIPTION
https://github.com/oven-sh/bun.report/commit/d5de2cf23729ec74b33156497aaac7f414db539c added an import from `zlib`.

Due to the use of `parse` on the frontend, unwanted code was being bundled:
![image](https://github.com/user-attachments/assets/e9b6ab13-c8ba-46b2-bd1c-357f32f81d1a)

I have locally tested that the server-side remap still parses the panic message and the frontend now works as expected.