### PR TITLE
Wrap error message in code block to prevent MarkDown formatting interference

### DIFF
--- a/lib/format.ts
+++ b/lib/format.ts
@@ -13,7 +13,9 @@ export function formatMarkdown(remap: Remap, internal?: { source: string }): str
   return [
     `Bun v${remap.version} (${treeURLMD(remap.commit)}) on ${remap.os} ${remap.arch} [${remap.command}]`,
     "",
-    remap.message.replace(/^panic: /, "**panic**: "),
+    "```",
+    remap.message.replace(/^panic: /, "PANIC: "),
+    "```",
     "",
     ...addrsToMarkdown(remap.commit.oid, remap.addresses).map((l) => `- ${l}`),
     "",


### PR DESCRIPTION
I am benchmarking Claude Code Max to see if it capable of fixing some low hanging fruit with oversight. Let me know if this is OK!

This specifically fixes @word being parsed as a GitHub username link and a forward slash preceding that @ sign disappearing in the MarkDown render.

Fixes https://github.com/oven-sh/bun/issues/20304

🤖 Generated with [Claude Code](https://claude.ai/code)