### PR TITLE
[ENG-14991] fix no file information on macOS

### DIFF
--- a/backend/debug-store.ts
+++ b/backend/debug-store.ts
@@ -146,7 +146,10 @@ async function fetchDebugFileWithoutCache(
       timeout: 60000,
     });
     if ((await subproc.exited) !== 0) {
-      const e: any = new Error("unzip failed: " + (await Bun.readableStreamToText(subproc.stderr)));
+      const reason = subproc.signalCode ?? `code ${subproc.exitCode}`;
+      const e: any = new Error(
+        `unzip ${join(tmp.path, dir + ".zip")} failed with ${reason}: ${await Bun.readableStreamToText(subproc.stderr)}`,
+      );
       e.code = "UnzipFailed";
       throw e;
     }
@@ -274,7 +277,10 @@ export async function tryFromPR(
     });
 
     if ((await subproc.exited) !== 0) {
-      const e: any = new Error("unzip failed: " + (await Bun.readableStreamToText(subproc.stderr)));
+      const reason = subproc.signalCode ?? `code ${subproc.exitCode}`;
+      const e: any = new Error(
+        `unzip ${join(temp, "artifact-download.zip")} failed with ${reason}: ${await Bun.readableStreamToText(subproc.stderr)}`,
+      );
       e.code = "UnzipFailed";
       throw e;
     }

--- a/backend/debug-store.ts
+++ b/backend/debug-store.ts
@@ -157,9 +157,10 @@ async function fetchDebugFileWithoutCache(
     let desired_file = join(tmp.path, dir, "bun" + store_suffix + "-profile");
     const entries = await readdir(join(tmp.path, dir));
 
-    if (os === "windows") {
+    const extension = os === "windows" ? ".pdb" : os === "macos" ? ".dSYM" : undefined;
+    if (extension) {
       for (const entry of entries) {
-        if (entry.endsWith(".pdb")) {
+        if (entry.endsWith(extension)) {
           desired_file = join(tmp.path, dir, entry);
           break;
         }

--- a/backend/debug-store.ts
+++ b/backend/debug-store.ts
@@ -143,7 +143,7 @@ async function fetchDebugFileWithoutCache(
       cmd: [unzip, join(tmp.path, dir + ".zip")],
       stdio: ["ignore", "pipe", "pipe"],
       cwd: tmp.path,
-      timeout: 5000,
+      timeout: 60000,
     });
     if ((await subproc.exited) !== 0) {
       const e: any = new Error("unzip failed: " + (await Bun.readableStreamToText(subproc.stderr)));
@@ -270,7 +270,7 @@ export async function tryFromPR(
       cmd: [unzip, join(temp, "artifact-download.zip")],
       stdio: ["ignore", "pipe", "pipe"],
       cwd: temp,
-      timeout: 5000,
+      timeout: 60000,
     });
 
     if ((await subproc.exited) !== 0) {

--- a/backend/remap.ts
+++ b/backend/remap.ts
@@ -45,6 +45,9 @@ const command_map: { [key: string]: string } = {
 const in_progress_remaps = new AsyncMutexMap<Remap>();
 
 export async function remap(parsed_string: string, parse: Parse): Promise<Remap> {
+  if (process.env.NODE_ENV === "development") {
+    return remapUncached(parsed_string, parse);
+  }
   const key = parseCacheKey(parse);
   const cached = getCachedRemap(key);
   parse.cache_key = key;


### PR DESCRIPTION
We need to pass the dSYM file to llvm-symbolizer instead of the executable.

before:

- *3 unknown/js code*
- `jsc_llint_commonCallOp__llintOpWithMetadata__llintOpWithReturn__llintOp__commonOp__fn__fn__makeReturn__fn__fn__fn__684_callHelper__dispatch_LowLevelInterpreter64_asm_2535`
- `llint_call_javascript`
- `JSC::Interpreter::executeModuleProgram`
- `JSC::JSModuleRecord::evaluate`
- `JSC::JSModuleLoader::evaluate`
- *1 unknown/js code*
- `jsc_llint_commonCallOp__llintOpWithMetadata__llintOpWithReturn__llintOp__commonOp__fn__fn__makeReturn__fn__fn__fn__684_callHelper__dispatch_LowLevelInterpreter64_asm_2535`

after:

- *3 unknown/js code*
- `jsc_llint_commonCallOp__llintOpWithMetadata__llintOpWithReturn__llintOp__commonOp__fn__fn__makeReturn__fn__fn__fn__684_callHelper__dispatch_LowLevelInterpreter64_asm_2535`
- `llint_call_javascript`
- [`Interpreter.cpp:1670`](<https://github.com/oven-sh/WebKit/blob/29bbdff0f94f362891f8e007ae2a73f9bc3e66d3/Source/JavaScriptCore/interpreter/Interpreter.cpp#L1670>): `JSC::Interpreter::executeModuleProgram`
- [`JSModuleRecord.cpp:321`](<https://github.com/oven-sh/WebKit/blob/29bbdff0f94f362891f8e007ae2a73f9bc3e66d3/Source/JavaScriptCore/runtime/JSModuleRecord.cpp#L321>): `JSC::JSModuleRecord::evaluate`
- [`JSModuleLoader.cpp:300`](<https://github.com/oven-sh/WebKit/blob/29bbdff0f94f362891f8e007ae2a73f9bc3e66d3/Source/JavaScriptCore/runtime/JSModuleLoader.cpp#L300>): `JSC::JSModuleLoader::evaluate`
- *1 unknown/js code*
- `jsc_llint_commonCallOp__llintOpWithMetadata__llintOpWithReturn__llintOp__commonOp__fn__fn__makeReturn__fn__fn__fn__684_callHelper__dispatch_LowLevelInterpreter64_asm_2535`
- 

After merging, in addition to the normal redeploy we should also delete `.cache/macos-*` because those directories have cached executables instead of dSYM files which would lead to still reporting bad traces for Bun versions the reporter has seen already.